### PR TITLE
Obstacle can now be marked as unresolved

### DIFF
--- a/app/controllers/obstacles_controller.rb
+++ b/app/controllers/obstacles_controller.rb
@@ -13,7 +13,7 @@ class ObstaclesController < ApplicationController
 
   def done
     @obstacle = Obstacle.find(params[:id])
-    @obstacle.update(done: true)
+    @obstacle.done? ? @obstacle.update(done: false) : @obstacle.update(done: true)
     redirect_to obstacles_path
   end
 

--- a/app/views/obstacles/_obstacle_resolved_card.html.erb
+++ b/app/views/obstacles/_obstacle_resolved_card.html.erb
@@ -1,4 +1,12 @@
-<div class="obstacle-resolved-card">
-  <i class="fa-solid fa-circle-check"></i>
-  <p>You've marked this obstacle as resolved</p>
+<div class="d-flex justify-content-between">
+
+  <div>
+    <%= (button_to "MARK OBSTACLE AS UNRESOLVED", done_path, method:'patch', class:"bootstrap-override-button mt-2 mb-5") %>
+  </div>
+
+  <div class="obstacle-resolved-card">
+    <i class="fa-solid fa-circle-check"></i>
+    <p>You've marked this obstacle as resolved</p>
+  </div>
+
 </div>


### PR DESCRIPTION
- edited the logic in the controller
- edited the css. Might be a nicer way to show this? Maybe remove the "you've marked this obstacle as resolved" now that there is a "Mark obstacle as unresolved" button? I leave this to the CSS queen

<img width="1236" alt="image" src="https://github.com/pablohennique/day-by-day/assets/56610219/a1951286-e59b-499e-9caa-a189b0d9d821">
