### PR TITLE
added simple_format helper to display recommendations text more clearly

### DIFF
--- a/app/assets/stylesheets/components/_recommendation_card.scss
+++ b/app/assets/stylesheets/components/_recommendation_card.scss
@@ -30,13 +30,13 @@
   border-bottom-right-radius: 10px;
   padding-left: 20px;
   padding-right: 20px;
+}
 
-  p {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: var(--read-more-line-clamp, 4);
-  }
+.my-content {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--read-more-line-clamp, 4);
 }
 
 .purple_title{

--- a/app/views/obstacles/_recommendation_card.html.erb
+++ b/app/views/obstacles/_recommendation_card.html.erb
@@ -14,7 +14,7 @@
 <div class ="reco-card-text">
   <div data-controller="read-more" data-read-more-more-text-value="Read more" data-read-more-less-text-value="Read less">
     <p class="my-content" data-read-more-target="content">
-      <%= recommendation.content %>
+      <%= simple_format recommendation.content %>
     </p>
     <button class="grey-link" data-action="click->read-more#toggle">Read more</button>
   </div>

--- a/app/views/obstacles/_recommendation_card.html.erb
+++ b/app/views/obstacles/_recommendation_card.html.erb
@@ -13,9 +13,9 @@
 
 <div class ="reco-card-text">
   <div data-controller="read-more" data-read-more-more-text-value="Read more" data-read-more-less-text-value="Read less">
-    <p class="my-content" data-read-more-target="content">
+    <div class="my-content" data-read-more-target="content">
       <%= simple_format recommendation.content %>
-    </p>
+    </div>
     <button class="grey-link" data-action="click->read-more#toggle">Read more</button>
   </div>
 </div>


### PR DESCRIPTION
- added 2 words to fix the display issue. ChatGPT was already giving us the response formatted in plain text. We just had to add a Rails helper to turn the \n\ lines into <p></p> (HTML). Now it looks pretty

<img width="641" alt="image" src="https://github.com/pablohennique/day-by-day/assets/56610219/e97fe1c6-5953-417f-8be8-10dbd57cdf78">
